### PR TITLE
Fix the source code link in the HTML output

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -30,7 +30,7 @@
     <footer>
       <p>
         Source code available on
-        <a href="https://numberformat.github.io/helppc_reference_library_html/">github.io</a>.
+        <a href="https://github.com/numberformat/helppc_reference_library_html">github.com</a>.
         <br />
         IBM VGA 8x14 font from the
         <a href="https://int10h.org/oldschool-pc-fonts">Ultimate oldschool PC font pack</a>


### PR DESCRIPTION
I think the link is supposed to point to the source code, not to the published version?